### PR TITLE
Fixed Docker Hub reference to locate image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ echo $1
 
 Then run the following command to spin up the docker container that runs hapttic:
 
-`docker run --rm -p 8080:8080 -v ~/hapttic_request_handler.sh:/hapttic_request_handler.sh --name hapttic hapttic -file "/hapttic_request_handler.sh"`
+`docker run --rm -p 8080:8080 -v ~/hapttic_request_handler.sh:/hapttic_request_handler.sh --name hapttic jsoendermann/hapttic -file "/hapttic_request_handler.sh"`
 
 Finally, run `open http://localhost:8080` to see the output of your script.
 


### PR DESCRIPTION
Added username to docker image to avoid 

```
Unable to find image 'hapttic:latest' locally
```

![image](https://user-images.githubusercontent.com/19626334/48811610-be716a00-ed15-11e8-96bb-17b88bb8407d.png)
